### PR TITLE
Loosen restriction on vmware-vra-gem version.

### DIFF
--- a/chef-provisioning-vra.gemspec
+++ b/chef-provisioning-vra.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'chef-provisioning'
-  spec.add_dependency 'vmware-vra',            '~> 1.3.0'
+  spec.add_dependency 'vmware-vra',            '~> 1.3'
 
   spec.add_development_dependency 'chef',      '>= 12'
   spec.add_development_dependency 'bundler',   '~> 1.7'


### PR DESCRIPTION
Version 1.5.0 of vmware-vra-gem has been released containing additional
fixes and support for different VM types.  The current gem version pin
in the gemspec is too restrictive.
