### PR TITLE
README update - hash rockets required for many extra parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ bootstrap_options: {
 }
 ```
 
+If your parameter name contains a hyphen, such as when you're passing in "provider" parameters, you will need to use the older "hash rocket" syntax:
+
+```ruby
+bootstrap_options: {
+  extra_parameters: {
+    'provider-MyCustomProperty' => {
+      type: 'string',
+      value: 'my value'
+    }
+  }
+}
+```
+
 ### Transport Options
 
 All transport options are optional.


### PR DESCRIPTION
Adding note about using hash-rocket syntax since many vRA parameters use hyphens.
