### PR TITLE
Adding exception retry logic to `#wait_for`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chef-provisioning-vra.gemspec
 gemspec
-


### PR DESCRIPTION
In the event that exceptions are raised while waiting for some actions,
such as connecting to a machine when DNS hasn't propagated, Chef
Provisioning will unwind and not retry the attempt. This change catches
those exceptions and adds a configurable retry count parameter.
