### PR TITLE
adding the vRA resource name to the chef node object

### DIFF
--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -62,6 +62,7 @@ class Chef
             'driver_url'     => driver_url,
             'driver_version' => Chef::Provisioning::VraDriver::VERSION,
             'resource_id'    => resource.id,
+            'resource_name'  => resource.name,
             'allocated_at'   => Time.now.utc.to_s,
             'is_windows'     => transport_options[:is_windows]
           }

--- a/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
+++ b/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
@@ -82,6 +82,7 @@ describe Chef::Provisioning::VraDriver::Driver do
           'driver_url'     => 'vra:https://vra-test.corp.local',
           'driver_version' => driver_version,
           'resource_id'    => 'test_id',
+          'resource_name'  => 'test_name',
           'allocated_at'   => 'test_time',
           'is_windows'     => false
         }
@@ -89,6 +90,7 @@ describe Chef::Provisioning::VraDriver::Driver do
 
       before do
         allow(resource).to receive(:id).and_return('test_id')
+        allow(resource).to receive(:name).and_return('test_name')
         allow(driver).to receive(:resource_for).and_return(nil)
         allow(driver).to receive(:bootstrap_options_for).and_return(bootstrap_options)
         allow(driver).to receive(:transport_options_for).and_return(transport_options)


### PR DESCRIPTION
vRA blueprints can create hosts/resources and auto-assign
hostnames that don't match the machine resource name. This
change will store the resource name on the chef node
object so that users can display/query it.
