### PR TITLE
WinRM transport and port options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.direnv/
+/.envrc
+/.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ cache: bundler
 sudo: false
 
 rvm:
-- 2.0.0
-- 2.1
-- 2.2
+- 2.2.2
+- 2.3.1
 
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in chef-provisioning-vra.gemspec

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ All transport options are optional.
  * `password`:
    * *Windows*: required.  Set to the user's password to use to log in via WinRM.
    * *Unix*: optional.  If set, SSH key authentication will not be used.
+ * `winrm_transport`: set this `negotiate`, `ssl`, or `plaintext` to determine the transport method to use.  Defaults to `negotiate`.  See [WinRM README](https://github.com/WinRb/WinRM) for more details.
+ * `winrm_port`: set the port to connect over WinRM.  Defaults to `5896` if the transport is set to `ssl` and `5895` for all others.
 
 ### Resources
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/chef-provisioning-vra.gemspec
+++ b/chef-provisioning-vra.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'chef/provisioning/vra_driver/version'

--- a/lib/chef/provisioning/driver_init/vra.rb
+++ b/lib/chef/provisioning/driver_init/vra.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Chef Partner Engineering (<partnereng@chef.io>)
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -276,7 +276,7 @@ class Chef
           winrm_options     = winrm_options_for(username, transport_options[:password])
 
           Chef::Log.debug("Creating WinRM connection to #{url}")
-          Chef::Provisioning::Transport::WinRM.new(url, :plaintext, winrm_options, config)
+          Chef::Provisioning::Transport::WinRM.new(url, winrm_transport, winrm_options, config)
         end
 
         def winrm_options_for(username, password)

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -269,9 +269,15 @@ class Chef
           transport_options = transport_options_for(machine_options)
           remote_host       = remote_host_for(machine_options, resource)
           username          = username_for(machine_spec, machine_options, 'Administrator')
-          url               = "http://#{remote_host}:5985/wsman"
+          winrm_transport   = transport_options[:winrm_transport].nil? ? :negotiate : transport_options[:winrm_transport].to_sym
+          Chef::Log.debug("WinRM transport: #{winrm_transport}")
+          winrm_port        = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
+          winrm_port ||= winrm_transport == :plaintext || winrm_transport == :negotiate ? 5985 : 5986
+          scheme            = winrm_transport == :plaintext || winrm_transport == :negotiate ? 'http' : 'https'
+          url               = "#{scheme}://#{remote_host}:#{winrm_port}/wsman"
           winrm_options     = winrm_options_for(username, transport_options[:password])
 
+          Chef::Log.debug("Creating WinRM connection to #{url}")
           Chef::Provisioning::Transport::WinRM.new(url, :plaintext, winrm_options, config)
         end
 

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -268,9 +268,15 @@ class Chef
           transport_options = transport_options_for(machine_options)
           remote_host       = remote_host_for(machine_options, resource)
           username          = username_for(machine_spec, machine_options, 'Administrator')
-          url               = "http://#{remote_host}:5985/wsman"
+          winrm_transport   = transport_options[:winrm_transport].nil? ? :negotiate : transport_options[:winrm_transport].to_sym
+          Chef::Log.debug("WinRM transport: #{winrm_transport}")
+          winrm_port        = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
+          winrm_port ||= winrm_transport == :plaintext || winrm_transport == :negotiate ? 5985 : 5986
+          scheme            = winrm_transport == :plaintext || winrm_transport == :negotiate ? 'http' : 'https'
+          url               = "#{scheme}://#{remote_host}:#{winrm_port}/wsman"
           winrm_options     = winrm_options_for(username, transport_options[:password])
 
+          Chef::Log.debug("Creating WinRM connection to #{url}")
           Chef::Provisioning::Transport::WinRM.new(url, :plaintext, winrm_options, config)
         end
 

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -270,7 +270,6 @@ class Chef
           remote_host       = remote_host_for(machine_options, resource)
           username          = username_for(machine_spec, machine_options, 'Administrator')
           winrm_transport   = transport_options[:winrm_transport].nil? ? :negotiate : transport_options[:winrm_transport].to_sym
-          Chef::Log.debug("WinRM transport: #{winrm_transport}")
           winrm_port        = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
           winrm_port ||= winrm_transport == :plaintext || winrm_transport == :negotiate ? 5985 : 5986
           scheme            = winrm_transport == :plaintext || winrm_transport == :negotiate ? 'http' : 'https'

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -269,15 +269,40 @@ class Chef
           transport_options = transport_options_for(machine_options)
           remote_host       = remote_host_for(machine_options, resource)
           username          = username_for(machine_spec, machine_options, 'Administrator')
-          winrm_transport   = transport_options[:winrm_transport].nil? ? :negotiate : transport_options[:winrm_transport].to_sym
-          winrm_port        = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
-          winrm_port ||= winrm_transport == :plaintext || winrm_transport == :negotiate ? 5985 : 5986
-          scheme            = winrm_transport == :plaintext || winrm_transport == :negotiate ? 'http' : 'https'
-          url               = "#{scheme}://#{remote_host}:#{winrm_port}/wsman"
+          winrm_trans_opts  = winrm_transport_options_for(remote_host, transport_options)
           winrm_options     = winrm_options_for(username, transport_options[:password])
 
-          Chef::Log.debug("Creating WinRM connection to #{url}")
-          Chef::Provisioning::Transport::WinRM.new(url, winrm_transport, winrm_options, config)
+          Chef::Log.debug("Creating WinRM connection to #{winrm_trans_opts[:url]}")
+          Chef::Provisioning::Transport::WinRM.new(
+            winrm_trans_opts[:url],
+            winrm_trans_opts[:winrm_transport],
+            winrm_options,
+            config
+          )
+        end
+
+        def winrm_transport_options_for(remote_host, transport_options)
+          winrm_port = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
+          case transport_options[:winrm_transport]
+          when nil
+            winrm_transport = :negotiate
+            scheme = 'http'
+            winrm_port ||= 5985
+          when 'ssl'
+            winrm_transport = :ssl
+            scheme = 'https'
+            winrm_port ||= 5986
+          when 'plaintext'
+            winrm_transport = :plaintext
+            scheme = 'http'
+            winrm_port ||= 5985
+          end
+          url = "#{scheme}://#{remote_host}:#{winrm_port}/wsman"
+
+          {
+            winrm_transport: winrm_transport,
+            url: url
+          }
         end
 
         def winrm_options_for(username, password)

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Chef Partner Engineering (<partnereng@chef.io>)
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
@@ -152,7 +153,7 @@ class Chef
 
           servers = submitted_request.resources.select(&:vm?)
           raise 'The vRA request created more than one server. The catalog blueprint should only return one.' if servers.size > 1
-          raise 'the vRA request did not create any servers.' if servers.size == 0
+          raise 'the vRA request did not create any servers.' if servers.size.zero?
 
           servers.first
         end

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -269,7 +269,6 @@ class Chef
           remote_host       = remote_host_for(machine_options, resource)
           username          = username_for(machine_spec, machine_options, 'Administrator')
           winrm_transport   = transport_options[:winrm_transport].nil? ? :negotiate : transport_options[:winrm_transport].to_sym
-          Chef::Log.debug("WinRM transport: #{winrm_transport}")
           winrm_port        = transport_options[:winrm_port] unless transport_options[:winrm_port].nil?
           winrm_port ||= winrm_transport == :plaintext || winrm_transport == :negotiate ? 5985 : 5986
           scheme            = winrm_transport == :plaintext || winrm_transport == :negotiate ? 'http' : 'https'

--- a/lib/chef/provisioning/vra_driver/driver.rb
+++ b/lib/chef/provisioning/vra_driver/driver.rb
@@ -277,7 +277,7 @@ class Chef
           winrm_options     = winrm_options_for(username, transport_options[:password])
 
           Chef::Log.debug("Creating WinRM connection to #{url}")
-          Chef::Provisioning::Transport::WinRM.new(url, :plaintext, winrm_options, config)
+          Chef::Provisioning::Transport::WinRM.new(url, winrm_transport, winrm_options, config)
         end
 
         def winrm_options_for(username, password)

--- a/lib/chef/provisioning/vra_driver/version.rb
+++ b/lib/chef/provisioning/vra_driver/version.rb
@@ -20,7 +20,7 @@
 class Chef
   module Provisioning
     module VraDriver
-      VERSION = '0.3.0'
+      VERSION = '0.3.0'.freeze
     end
   end
 end

--- a/lib/chef/provisioning/vra_driver/version.rb
+++ b/lib/chef/provisioning/vra_driver/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Chef Partner Engineering (<partnereng@chef.io>)
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
@@ -19,7 +20,7 @@
 class Chef
   module Provisioning
     module VraDriver
-      VERSION = '0.3.0'.freeze
+      VERSION = '0.3.0'
     end
   end
 end

--- a/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
+++ b/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
@@ -699,20 +699,6 @@ describe Chef::Provisioning::VraDriver::Driver do
       expect(driver.create_winrm_transport(machine_spec, machine_options, resource)).to eq(transport)
     end
 
-    it 'creates a proper transport instance with plaintext and returns it' do
-      allow(driver).to receive(:transport_options_for).and_return(transport_options_plaintext)
-      allow(driver).to receive(:remote_host_for).and_return('test-host')
-      allow(driver).to receive(:winrm_options_for).and_return(winrm_options)
-      allow(driver).to receive(:username_for).and_return('test_username')
-
-      expect(Chef::Provisioning::Transport::WinRM).to receive(:new).with('http://test-host:5985/wsman',
-                                                                         :plaintext,
-                                                                         winrm_options,
-                                                                         config).and_return(transport)
-
-      expect(driver.create_winrm_transport(machine_spec, machine_options, resource)).to eq(transport)
-    end
-
     it 'creates a proper transport instance with ssl on port 22 and returns it' do
       allow(driver).to receive(:transport_options_for).and_return(transport_options_ssl)
       allow(driver).to receive(:remote_host_for).and_return('test-host')
@@ -725,6 +711,28 @@ describe Chef::Provisioning::VraDriver::Driver do
                                                                          config).and_return(transport)
 
       expect(driver.create_winrm_transport(machine_spec, machine_options, resource)).to eq(transport)
+    end
+  end
+
+  describe '#winrm_transport_options_for' do
+    context 'when the transport options are not defined' do
+      let(:default_transport_options) { { winrm_transport: :negotiate, url: 'http://test-host:5985/wsman' } }
+      it 'returns a default transport options hash' do
+        expect(driver.winrm_transport_options_for('test-host', {})).to eq(default_transport_options)
+      end
+    end
+
+    context 'when the transport options include ssl and a port' do
+      let(:ssl_transport_options) { { winrm_transport: :ssl, url: 'https://test-host:22/wsman' } }
+      it 'returns a transport with https and the right port' do
+        expect(
+          driver.winrm_transport_options_for(
+            'test-host',
+            winrm_transport: 'ssl',
+            winrm_port: 22
+          )
+        ).to eq(ssl_transport_options)
+      end
     end
   end
 

--- a/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
+++ b/spec/unit/chef/provisioning/vra_driver/driver_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Author:: Chef Partner Engineering (<partnereng@chef.io>)
 # Copyright:: Copyright (c) 2015 Chef Software, Inc.
@@ -691,8 +692,7 @@ describe Chef::Provisioning::VraDriver::Driver do
       expect(Chef::Provisioning::Transport::WinRM).to receive(:new).with('http://test-host:5985/wsman',
                                                                          :plaintext,
                                                                          winrm_options,
-                                                                         config
-                                                                        ).and_return(transport)
+                                                                         config).and_return(transport)
 
       expect(driver.create_winrm_transport(machine_spec, machine_options, resource)).to eq(transport)
     end
@@ -746,8 +746,7 @@ describe Chef::Provisioning::VraDriver::Driver do
                                                                        'test_username',
                                                                        ssh_options,
                                                                        options,
-                                                                       config
-                                                                      ).and_return(transport)
+                                                                       config).and_return(transport)
 
       expect(driver.create_ssh_transport(machine_spec, machine_options, resource)).to eq(transport)
     end
@@ -988,8 +987,7 @@ describe Chef::Provisioning::VraDriver::Driver do
                                                 username: 'test_username',
                                                 password: 'test_password',
                                                 tenant:   'test_tenant',
-                                                verify_ssl: true
-                                               ).and_return(client)
+                                                verify_ssl: true).and_return(client)
 
       expect(driver.vra_client).to eq(client)
     end


### PR DESCRIPTION
Adding a few more options to the `transport_options`, specifically transport and port.
Also determining the scheme based off of the transport type.
